### PR TITLE
Case-insensitive URL parsing

### DIFF
--- a/slave/src/main/scala/fi/pyppe/ircbot/slave/SlaveSystem.scala
+++ b/slave/src/main/scala/fi/pyppe/ircbot/slave/SlaveSystem.scala
@@ -137,7 +137,7 @@ object SlaveWorker {
   val GistUrl = """(?:.*gist\.github\.com/).*/([0-9]+)""".r
   val Rain = """!sää(t?) ?(.*)""".r
 
-  val UrlRegex = ("\\b(((ht|f)tp(s?)\\:\\/\\/|~\\/|\\/)|www.)" +
+  val UrlRegex = ("(?i)\\b(((ht|f)tp(s?)\\:\\/\\/|~\\/|\\/)|www.)" +
     "(\\w+:\\w+@)?(([-\\w]+\\.)+(com|org|net|gov" +
     "|mil|biz|info|mobi|name|aero|jobs|museum" +
     "|travel|[a-z]{2}))(:[\\d]{1,5})?" +

--- a/slave/src/test/scala/fi/pyppe/ircbot/slave/SlaveWorkerSpec.scala
+++ b/slave/src/test/scala/fi/pyppe/ircbot/slave/SlaveWorkerSpec.scala
@@ -1,0 +1,28 @@
+package fi.pyppe.ircbot.slave
+
+import org.specs2.mutable._
+
+class SlaveWorkerSpec extends Specification {
+
+  "SlaveWorker.parseUrls" should {
+    def test(input: String, urls : List[String]) =
+      s"find [$urls] from [$input]" in {
+        SlaveWorker.parseUrls(input) === urls
+    }
+
+    test("", List())
+    test("http://", List())
+    test("http://google.com", List("http://google.com"))
+    test("https://google.com", List("https://google.com"))
+    test("Some Text here http://www.google.com, cool", List("http://www.google.com"))
+    test("http://www.google.com testing", List("http://www.google.com"))
+    test("HTTP://WWW.GOOGLE.COM", List("HTTP://WWW.GOOGLE.COM"))
+
+    // some urls with entities, upper & lowercase
+    test("http://www.hs.fi/ulkomaat/Valko-Ven%C3%A4j%C3%A4n+Luka%C5%A1enka+suunnittelee+maaorjuutta/a1401330071381",
+      List("http://www.hs.fi/ulkomaat/Valko-Ven%C3%A4j%C3%A4n+Luka%C5%A1enka+suunnittelee+maaorjuutta/a1401330071381"))
+
+    test("http://www.hs.fi/ulkomaat/valko-ven%c3%a4j%c3%a4n+luka%c5%a1enka+suunnittelee+maaorjuutta/a1401330071381",
+      List("http://www.hs.fi/ulkomaat/valko-ven%c3%a4j%c3%a4n+luka%c5%a1enka+suunnittelee+maaorjuutta/a1401330071381"))
+  }
+}


### PR DESCRIPTION
SlaveWorker's parseUrl only matched properly lowercase URLs for now and URLs containing uppercase entities got truncated. For example http://foo.com/ven%C3%A4j%C3%A4 was parsed as http://foo.com/ven.
